### PR TITLE
Don't install as `src` and don't mutate input sequence

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setup(
     author="Vladimir Seregin",
     author_email="31631@rambler.ru",
     license="MIT",
-    packages=find_packages(),
+    packages=find_packages(where='src'),
     install_requires=[],
     setup_requires=[
         'setuptools_scm',

--- a/src/percentiles.py
+++ b/src/percentiles.py
@@ -13,7 +13,7 @@ def percentile(N: Iterable, percent: int):
     if not (0 < percent < 100 and type(percent) == int):
         raise ValueError('percent parameter must be integer from 0 to 100')
 
-    N.sort()
+    N = sorted(N)
 
     k = (len(N) - 1) * percent / 100
     prev_index = math.floor(k)

--- a/test/test_percentiles.py
+++ b/test/test_percentiles.py
@@ -2,7 +2,7 @@ from functools import partial
 
 import pytest
 
-from src.percentiles import percentile
+from percentiles import percentile
 
 
 percentile_75 = partial(percentile, percent=75)


### PR DESCRIPTION
Hi. 

Thanks for your work! I found a couple of issues, though.

The package is now installed as `src`, which makes little sense. I propose to install it as `percentiles`.

You also mutate input sequence, which may be undesirable. I propose to copy the sequence and sort the copy.